### PR TITLE
Replace python-bitcoinrpc dependency with built-in client

### DIFF
--- a/bitcoinrpc/__init__.py
+++ b/bitcoinrpc/__init__.py
@@ -1,0 +1,4 @@
+"""Lightweight JSON-RPC client for Elements/Bitcoin RPC."""
+from .authproxy import AuthServiceProxy, JSONRPCException
+
+__all__ = ["AuthServiceProxy", "JSONRPCException"]

--- a/bitcoinrpc/authproxy.py
+++ b/bitcoinrpc/authproxy.py
@@ -1,0 +1,110 @@
+"""Minimal AuthServiceProxy implementation for Elements JSON-RPC."""
+from __future__ import annotations
+
+import base64
+import itertools
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
+from urllib import request
+
+
+class JSONRPCException(RuntimeError):
+    """Exception raised for JSON-RPC errors returned by the node."""
+
+    def __init__(self, error: Dict[str, Any]):
+        self.code = error.get("code")
+        self.message = error.get("message", "Unknown error")
+        super().__init__(f"RPC error {self.code}: {self.message}")
+
+
+@dataclass
+class _RPCMethod:
+    """Callable proxy for a remote RPC method."""
+
+    proxy: "AuthServiceProxy"
+    method: str
+
+    def __call__(self, *args: Any) -> Any:
+        return self.proxy._call(self.method, args)
+
+
+class AuthServiceProxy:
+    """Lightweight drop-in replacement for python-bitcoinrpc's proxy."""
+
+    def __init__(
+        self,
+        service_url: str,
+        *,
+        timeout: Optional[float] = 30.0,
+    ) -> None:
+        self._service_url = service_url
+        self._timeout = timeout
+        self._request_id = itertools.count(1)
+        self._headers = {
+            "Content-Type": "application/json",
+        }
+
+        # Extract credentials for basic auth
+        if "@" in service_url and "//" in service_url:
+            scheme, rest = service_url.split("//", 1)
+            creds, endpoint = rest.split("@", 1)
+            self._service_url = f"{scheme}//{endpoint}"
+            self._headers["Authorization"] = "Basic " + base64.b64encode(
+                creds.encode()
+            ).decode()
+
+    def __getattr__(self, name: str) -> _RPCMethod:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return _RPCMethod(self, name)
+
+    def batch(self, calls: Iterable[tuple[str, Iterable[Any]]]) -> list[Any]:
+        """Execute a batch of RPC calls."""
+
+        payload = [
+            {
+                "jsonrpc": "2.0",
+                "id": next(self._request_id),
+                "method": method,
+                "params": list(params),
+            }
+            for method, params in calls
+        ]
+        data = self._post(json.dumps(payload).encode())
+        result = json.loads(data.decode())
+        if not isinstance(result, list):
+            raise RuntimeError("Invalid batch response")
+        return [self._extract_result(item) for item in result]
+
+    def _call(self, method: str, params: Iterable[Any]) -> Any:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": next(self._request_id),
+            "method": method,
+            "params": list(params),
+        }
+        data = self._post(json.dumps(payload).encode())
+        result = json.loads(data.decode())
+        return self._extract_result(result)
+
+    def _post(self, payload: bytes) -> bytes:
+        req = request.Request(self._service_url, data=payload, headers=self._headers)
+        with request.urlopen(req, timeout=self._timeout) as response:
+            return response.read()
+
+    def _extract_result(self, data: Dict[str, Any]) -> Any:
+        if not isinstance(data, dict):
+            raise RuntimeError("Invalid JSON-RPC response")
+        if data.get("error"):
+            raise JSONRPCException(data["error"])
+        return data.get("result")
+
+    def close(self) -> None:
+        """Compatibility stub for context manager usage."""
+
+    def __enter__(self) -> "AuthServiceProxy":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Real, working RFQ protocol for confidential OTC settlement on Liquid Network using:
 - **Confidential Transactions** - Amounts hidden via Pedersen commitments
-- **PSETs** - Atomic swaps eliminate escrow risk  
+- **PSETs** - Atomic swaps eliminate escrow risk
 - **Real Elements RPC** - Not pseudocode, actual blockchain operations
 - **2-minute finality** - Liquid's 1-minute blocks with 1-block confirmation
 
@@ -10,18 +10,18 @@ Real, working RFQ protocol for confidential OTC settlement on Liquid Network usi
 
 - Elements Core (elementsd / elements-cli) v0.21.0.3 or newer in your PATH
 - Python 3.11+
-- `python-bitcoinrpc` (install via `pip install -r requirements.txt`)
 
 ## Run It
 ```bash
 # 1. Start Liquid regtest
 bash setup_liquid_regtest.sh
 
-# 2. Install dependencies
-pip install -r requirements.txt
+# 2. (Optional) Review requirements
+pip install -r requirements.txt  # No external packages needed
 
 # 3. Run demo
 python3 rfq_otc.py
 
 # (optional) Inspect the blinded settlement transaction
 elements-cli -regtest gettransaction <txid>
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-bitcoinrpc==1.0
+# No external dependencies required.


### PR DESCRIPTION
## Summary
- add a lightweight in-repo implementation of AuthServiceProxy to avoid the broken python-bitcoinrpc dependency
- update documentation to reflect the simpler setup with no external Python requirements

## Testing
- python - <<'PY'
from bitcoinrpc.authproxy import AuthServiceProxy
proxy = AuthServiceProxy('http://user:pass@127.0.0.1:18884')
print('created', bool(proxy))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e55c14509c8320baa0b10bdeb798e7