### PR TITLE
Improve RPC error handling for OTC demo

### DIFF
--- a/rfq_otc.py
+++ b/rfq_otc.py
@@ -478,7 +478,14 @@ def demo_confidential_otc_settlement():
     l_btc_asset = rpc.dumpassetlabels()['bitcoin']
     
     # For demo: issue L-USDt test asset
-    l_usdt_asset = rpc.issueasset(100000, 0)['asset']
+    try:
+        l_usdt_asset = rpc.issueasset(100000, 0)['asset']
+    except JSONRPCException as exc:
+        raise RuntimeError(
+            "Failed to issue demo asset. Ensure the regtest wallet has matured "
+            "L-BTC to cover issuance fees and supports confidential transactions. "
+            f"Underlying RPC error: {exc.message}"
+        ) from exc
     rpc.sendtoaddress(dealer1_addr, 100000, "", "", False, False, 1, "UNSET", False, l_usdt_asset)
     rpc.sendtoaddress(dealer2_addr, 100000, "", "", False, False, 1, "UNSET", False, l_usdt_asset)
     rpc.generatetoaddress(1, client_addr)


### PR DESCRIPTION
## Summary
- surface Elements RPC failures as JSONRPCException by decoding HTTP 500 responses
- provide clearer RuntimeError when asset issuance fails during the OTC demo

## Testing
- python3 -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e65c687ce483208514e56b0336cfb5