### PR TITLE
Launch Liquid regtest on elementsregtest chain

### DIFF
--- a/docs/mvp_scope.md
+++ b/docs/mvp_scope.md
@@ -11,8 +11,8 @@ This document consolidates the minimum viable product (MVP) definition, validati
 | Capability | Code Anchor | Validation Command |
 |------------|-------------|--------------------|
 | Confidential settlement via blinded PSET | `LiquidRFQProtocol.create_atomic_settlement` | `python3 rfq_otc.py` → look for `✅ Settlement complete!` |
-| Bilateral signatures with reclaim path | `LiquidRFQProtocol.build_joint_timelocked_address` | `elements-cli -regtest validateaddress <protected_address>` |
-| Authentic Liquid RPC integration | `LiquidRFQProtocol.__init__` / `AuthServiceProxy` | `elements-cli -regtest getblockcount` while demo runs |
+| Bilateral signatures with reclaim path | `LiquidRFQProtocol.build_joint_timelocked_address` | `elements-cli -chain=elementsregtest validateaddress <protected_address>` |
+| Authentic Liquid RPC integration | `LiquidRFQProtocol.__init__` / `AuthServiceProxy` | `elements-cli -chain=elementsregtest getblockcount` while demo runs |
 | Deterministic quoting spread | `OTCDesk.process_rfq` | Inspect printed dealer quotes in demo output |
 
 ## MVP Acceptance Criteria
@@ -25,8 +25,8 @@ This document consolidates the minimum viable product (MVP) definition, validati
 1. Launch regtest – `bash setup_liquid_regtest.sh`.
 2. Install dependencies – `pip install -r requirements.txt`.
 3. Execute demo – `python3 rfq_otc.py`.
-4. Inspect transaction – `elements-cli -regtest gettransaction <txid>`.
-5. Validate descriptor – `elements-cli -regtest validateaddress <protected_address>`.
+4. Inspect transaction – `elements-cli -chain=elementsregtest gettransaction <txid>`.
+5. Validate descriptor – `elements-cli -chain=elementsregtest validateaddress <protected_address>`.
 
 If a step fails, restart `elementsd` and re-run from step 1. Regtest data lives under `~/.elements/regtest` and can be safely deleted to reset.
 

--- a/readme.md
+++ b/readme.md
@@ -29,10 +29,10 @@ The `rfq_otc.py` script wires these pieces together to demonstrate an end-to-end
 Triple-check the MVP functionality with this short runbook:
 
 1. **Environment sanity** – Elements `0.21.0.3+` is on your `PATH`, Python is `3.11+`, and `python-bitcoinrpc` is installed.
-2. **Regtest boot** – `bash setup_liquid_regtest.sh` returns `Liquid regtest ready!` and `elements-cli -regtest getblockcount` succeeds.
+2. **Regtest boot** – `bash setup_liquid_regtest.sh` returns `Liquid regtest ready!` and `elements-cli -chain=elementsregtest getblockcount` succeeds.
 3. **RFQ loop** – `python3 rfq_otc.py` finishes with `✅ Settlement complete!` and prints the blinded transaction ID.
-4. **Privacy guarantees** – `elements-cli -regtest gettransaction <txid>` shows blinded outputs (amounts hidden).
-5. **Timelock assurance** – `elements-cli -regtest validateaddress <protected_address>` reveals the imported Miniscript descriptor containing `older(...)`.
+4. **Privacy guarantees** – `elements-cli -chain=elementsregtest gettransaction <txid>` shows blinded outputs (amounts hidden).
+5. **Timelock assurance** – `elements-cli -chain=elementsregtest validateaddress <protected_address>` reveals the imported Miniscript descriptor containing `older(...)`.
 
 If any step fails, wipe `~/.elements/regtest`, restart `elementsd`, and rerun the commands.
 
@@ -81,14 +81,14 @@ pip install -r requirements.txt
 python3 rfq_otc.py
 
 # 4. Inspect the blinded settlement transaction (optional)
-elements-cli -regtest gettransaction <txid>
+elements-cli -chain=elementsregtest gettransaction <txid>
 ```
 
 ### Regtest readiness guardrail
 The demo now performs a pre-flight checklist before generating any addresses:
 
 1. **RPC connectivity** – Fails fast if the client cannot reach `elementsd` on regtest.
-2. **Chain validation** – Aborts when the node reports anything other than `regtest`/`liquidregtest`.
+2. **Chain validation** – Aborts when the node reports anything other than `elementsregtest`/`liquidregtest`.
 3. **Wallet availability** – Confirms that a wallet with private keys is loaded and unlocked.
 4. **Critical RPC coverage** – Verifies support for `blindpsbt`, `walletprocesspsbt`, `dumpmasterblindingkey`, and `signmessage`.
 

--- a/setup_liquid_regtest.sh
+++ b/setup_liquid_regtest.sh
@@ -16,22 +16,23 @@ RPC_USER="${LIQUID_RPC_USER:-user}"
 RPC_PASSWORD="${LIQUID_RPC_PASSWORD:-pass}"
 RPC_PORT="${LIQUID_RPC_PORT:-18884}"
 DATA_ROOT="${LIQUID_DATA_DIR:-$HOME/.elements}"
-REGTEST_DIR="${DATA_ROOT%/}/regtest"
+CHAIN_NAME="${LIQUID_CHAIN_NAME:-elementsregtest}"
+CHAIN_DIR="${DATA_ROOT%/}/${CHAIN_NAME}"
 WALLET_NAME="${LIQUID_WALLET_NAME:-test_wallet}"
 
 cli() {
-  elements-cli -regtest \
+  elements-cli -chain="${CHAIN_NAME}" \
     -datadir="${DATA_ROOT}" \
     -rpcuser="${RPC_USER}" \
     -rpcpassword="${RPC_PASSWORD}" \
     -rpcport="${RPC_PORT}" "$@"
 }
 
-mkdir -p "${REGTEST_DIR}"
+mkdir -p "${CHAIN_DIR}"
 
-echo "Ensuring elementsd is running (data dir: ${REGTEST_DIR})..."
+echo "Ensuring elementsd is running (data dir: ${CHAIN_DIR})..."
 if ! cli getblockchaininfo >/dev/null 2>&1; then
-  elementsd -regtest -daemon \
+  elementsd -chain="${CHAIN_NAME}" -daemon \
     -datadir="${DATA_ROOT}" \
     -rpcuser="${RPC_USER}" \
     -rpcpassword="${RPC_PASSWORD}" \


### PR DESCRIPTION
## Summary
- update the regtest helper to run elementsd/elements-cli with `-chain=elementsregtest`
- adjust readiness messaging and docs to guide operators toward the correct Elements chain

## Testing
- python3 -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e65c687ce483208514e56b0336cfb5