### PR TITLE
Guard against running demo on Bitcoin regtest

### DIFF
--- a/docs/mvp_scope.md
+++ b/docs/mvp_scope.md
@@ -11,8 +11,8 @@ This document consolidates the minimum viable product (MVP) definition, validati
 | Capability | Code Anchor | Validation Command |
 |------------|-------------|--------------------|
 | Confidential settlement via blinded PSET | `LiquidRFQProtocol.create_atomic_settlement` | `python3 rfq_otc.py` → look for `✅ Settlement complete!` |
-| Bilateral signatures with reclaim path | `LiquidRFQProtocol.build_joint_timelocked_address` | `elements-cli -chain=elementsregtest validateaddress <protected_address>` |
-| Authentic Liquid RPC integration | `LiquidRFQProtocol.__init__` / `AuthServiceProxy` | `elements-cli -chain=elementsregtest getblockcount` while demo runs |
+| Bilateral signatures with reclaim path | `LiquidRFQProtocol.build_joint_timelocked_address` | `elements-cli -chain=liquidregtest validateaddress <protected_address>` |
+| Authentic Liquid RPC integration | `LiquidRFQProtocol.__init__` / `AuthServiceProxy` | `elements-cli -chain=liquidregtest getblockcount` while demo runs |
 | Deterministic quoting spread | `OTCDesk.process_rfq` | Inspect printed dealer quotes in demo output |
 
 ## MVP Acceptance Criteria
@@ -25,10 +25,10 @@ This document consolidates the minimum viable product (MVP) definition, validati
 1. Launch regtest – `bash setup_liquid_regtest.sh`.
 2. Install dependencies – `pip install -r requirements.txt`.
 3. Execute demo – `python3 rfq_otc.py`.
-4. Inspect transaction – `elements-cli -chain=elementsregtest gettransaction <txid>`.
-5. Validate descriptor – `elements-cli -chain=elementsregtest validateaddress <protected_address>`.
+4. Inspect transaction – `elements-cli -chain=liquidregtest gettransaction <txid>`.
+5. Validate descriptor – `elements-cli -chain=liquidregtest validateaddress <protected_address>`.
 
-If a step fails, restart `elementsd` and re-run from step 1. Regtest data lives under `~/.elements/regtest` and can be safely deleted to reset.
+If a step fails, restart `elementsd` and re-run from step 1. Regtest data lives under `~/.elements/liquidregtest` (or `~/.elements/elementsregtest` on older versions) and can be safely deleted to reset.
 
 ## PlanB Positioning Notes
 - **Deep & private liquidity:** The flow assumes multiple dealers, each sourcing their own inventory, while the settlement remains confidential. Liquidity depth is represented by the ability to plug additional OTCDesk instances without altering the protocol layer.

--- a/readme.md
+++ b/readme.md
@@ -29,12 +29,12 @@ The `rfq_otc.py` script wires these pieces together to demonstrate an end-to-end
 Triple-check the MVP functionality with this short runbook:
 
 1. **Environment sanity** – Elements `0.21.0.3+` is on your `PATH`, Python is `3.11+`, and `python-bitcoinrpc` is installed.
-2. **Regtest boot** – `bash setup_liquid_regtest.sh` returns `Liquid regtest ready!` and `elements-cli -chain=elementsregtest getblockcount` succeeds.
+2. **Regtest boot** – `bash setup_liquid_regtest.sh` returns `Liquid regtest ready!` and `elements-cli -chain=liquidregtest getblockcount` succeeds (pass `-chain=elementsregtest` if running an older Elements build).
 3. **RFQ loop** – `python3 rfq_otc.py` finishes with `✅ Settlement complete!` and prints the blinded transaction ID.
-4. **Privacy guarantees** – `elements-cli -chain=elementsregtest gettransaction <txid>` shows blinded outputs (amounts hidden).
+4. **Privacy guarantees** – `elements-cli -chain=liquidregtest gettransaction <txid>` shows blinded outputs (amounts hidden).
 5. **Timelock assurance** – `elements-cli -chain=elementsregtest validateaddress <protected_address>` reveals the imported Miniscript descriptor containing `older(...)`.
 
-If any step fails, wipe `~/.elements/regtest`, restart `elementsd`, and rerun the commands.
+If any step fails, wipe `~/.elements/liquidregtest` (or `~/.elements/elementsregtest` on older builds), restart `elementsd`, and rerun the commands.
 
 ## Unique Positioning for PlanB
 PlanB is prioritising venues that can aggregate **deep, private liquidity** for institutional OTC flows. LIQTO supports that mandate in three ways:
@@ -81,7 +81,7 @@ pip install -r requirements.txt
 python3 rfq_otc.py
 
 # 4. Inspect the blinded settlement transaction (optional)
-elements-cli -chain=elementsregtest gettransaction <txid>
+elements-cli -chain=liquidregtest gettransaction <txid>
 ```
 
 ### Regtest readiness guardrail

--- a/rfq_otc.py
+++ b/rfq_otc.py
@@ -59,15 +59,16 @@ def ensure_regtest_readiness(rpc: AuthServiceProxy) -> dict:
     except Exception as exc:  # pragma: no cover - network/IO guard
         raise EnvironmentError(
             "Cannot reach Elements RPC. Start regtest via ``setup_liquid_regtest.sh`` "
-            "or ensure elementsd is running with ``-chain=elementsregtest``."
+            "or ensure elementsd is running with ``-chain=liquidregtest`` (``-chain=""
+            "elementsregtest`` on older versions)."
         ) from exc
 
     chain = chain_info.get("chain", "")
     if chain not in {"elementsregtest", "liquidregtest"}:
         raise EnvironmentError(
             "RFQ demo requires a Liquid regtest node. Current chain is "
-            f"'{chain}'. Restart elementsd with ``-chain=elementsregtest`` or "
-            "rerun the setup script."
+            f"'{chain}'. Restart elementsd with ``-chain=liquidregtest`` (or ``-chain=""
+            "elementsregtest`` for legacy builds) or rerun the setup script."
         )
 
     try:
@@ -75,22 +76,24 @@ def ensure_regtest_readiness(rpc: AuthServiceProxy) -> dict:
     except Exception as exc:  # pragma: no cover - wallet guard
         raise EnvironmentError(
             "Wallet RPC is unavailable. Start elementsd with wallet support and "
-            "load or create a default wallet (``elements-cli -chain=elementsregtest "
-            "createwallet wallet``)."
+            "load or create a default wallet (``elements-cli -chain=liquidregtest "
+            "createwallet wallet``; replace the chain with ``elementsregtest`` when "
+            "using older builds)."
         ) from exc
 
     if not wallet_info.get("private_keys_enabled", True):
         raise EnvironmentError(
-            "Loaded wallet is watch-only. Re-run ``elements-cli -chain=elementsregtest "
-            "createwallet`` with private keys enabled or load a wallet that holds "
-            "signing keys."
+            "Loaded wallet is watch-only. Re-run ``elements-cli -chain=liquidregtest "
+            "createwallet`` with private keys enabled (use ``elementsregtest`` on "
+            "older versions) or load a wallet that holds signing keys."
         )
 
     unlocked_until = wallet_info.get("unlocked_until")
     if unlocked_until is not None and unlocked_until == 0:
         raise EnvironmentError(
             "Wallet is locked. Unlock it first using ``elements-cli "
-            "-chain=elementsregtest walletpassphrase <passphrase> 600``."
+            "-chain=liquidregtest walletpassphrase <passphrase> 600`` (or replace "
+            "the chain argument with ``elementsregtest`` on legacy builds)."
         )
 
     missing_cmds = []


### PR DESCRIPTION
## Summary
- default the helper script to Elements' liquidregtest chain and refuse accidental Bitcoin regtest launches
- verify the daemon came up on the expected chain before declaring success
- refresh user-facing docs and readiness errors to mention the new chain name fallback guidance

## Testing
- not run (environment lacks Elements Core binaries)


------
https://chatgpt.com/codex/tasks/task_e_68e66279e7688320b0670df67b21c0af